### PR TITLE
Fixed issues with some upnp devices

### DIFF
--- a/lib/rupnp/cp/remote_device.rb
+++ b/lib/rupnp/cp/remote_device.rb
@@ -237,8 +237,9 @@ module RUPNP
     def extract_icons
       return unless @description[:root][:device][:icon_list]
       @description[:root][:device][:icon_list][:icon].each do |h|
+        h = Hash[*h] if h.is_a? Array
         icon = OpenStruct.new(h)
-        icon.url = build_url(@url_base, icon.url)
+        icon.url = build_url(@url_base, icon.url) unless icon.url.nil?
         @icons << icon
       end
     end

--- a/lib/rupnp/cp/remote_device.rb
+++ b/lib/rupnp/cp/remote_device.rb
@@ -214,7 +214,7 @@ module RUPNP
         @url_base =  @description[:root][:url_base]
         @url_base += '/' unless @url_base.end_with?('/')
       else
-        @url_base = @location.match(/[^\/]*\z/).pre_match
+        @url_base = @location.match('^.+?[^\/:](?=[?\/]|$)\/').to_s
       end
     end
 

--- a/lib/rupnp/cp/remote_service.rb
+++ b/lib/rupnp/cp/remote_service.rb
@@ -291,7 +291,7 @@ module RUPNP
           @actions = scpd[:scpd][:action_list][:action]
           @actions = [@actions] unless @actions.is_a? Array
           @actions.each do |action|
-            action[:arguments] = action[:argument_list][:argument]
+            action[:arguments] = action[:argument_list][:argument] unless action[:argument_list].nil?
             action.delete :argument_list
             define_method_from_action action
           end


### PR DESCRIPTION
- Fixed issue with empty icon description
- Fixed base url regexp when baseurl is not provided within the device
- Fixed issue with empty argument list for an action

All these issues can be reproduced and verified when searching for a device that is running BubbleUPNP (for android).
