### PR TITLE
Unified snake_case usage.

### DIFF
--- a/lib/rupnp.rb
+++ b/lib/rupnp.rb
@@ -6,7 +6,7 @@ require 'eventmachine-le'
 module RUPNP
 
   # RUPNP version
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 
   @logdev = STDERR
   @log_level = :info

--- a/lib/rupnp/cp/base.rb
+++ b/lib/rupnp/cp/base.rb
@@ -23,7 +23,7 @@ module RUPNP
       }
 
       def initialize
-        @parser = Nori.new(:convert_tags_to => ->(tag){ tag.snakecase.to_sym })
+        @parser = Nori.new(:convert_tags_to => ->(tag){ snake_case(tag).to_sym })
       end
 
       # Get description from +location+

--- a/lib/rupnp/cp/remote_service.rb
+++ b/lib/rupnp/cp/remote_service.rb
@@ -378,11 +378,12 @@ module RUPNP
           globals.log_level :error
           globals.endpoint @control_url
           globals.namespace @type
-          globals.convert_request_keys_to :camel_case
+          globals.convert_request_keys_to :camelcase
           globals.log true
           globals.headers :HOST => "#{HOST_IP}"
           globals.env_namespace 's'
           globals.namespace_identifier 'u'
+          globals.convert_response_tags_to ->(tag){ snake_case(tag).to_sym }
         end
       end
 

--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -16,16 +16,14 @@ EOF
 
   files = Dir['{spec,lib,bin,tasks}/**/*']
   files += ['README.md', 'MIT-LICENSE', 'Rakefile']
-  # For now, device is not in gem.
-  files -= ['lib/rupnp/device.rb', 'spec/device_spec.rb']
   s.files = files
   s.executables = ["discover"]
 
   s.add_dependency 'uuid', '~>2.3.0'
   s.add_dependency 'eventmachine-le', '~> 1.1.6'
   s.add_dependency 'em-http-request', '~> 1.1.1'
-  s.add_dependency 'nori', '~> 2.3.0'
-  s.add_dependency 'savon', '~>2.3.0'
+  s.add_dependency 'nori', '~> 2.4.0'
+  s.add_dependency 'savon', '>=2.6.0'
   s.add_dependency 'pry', '~>0.9.12'
 
   s.add_development_dependency 'rspec', '~>2.14.0'


### PR DESCRIPTION
Use same snake_case in all places. Corrects problem where wrong method format is used when receiving response in some cases (e.g. SetCurrentAVUri (camel case) -> set_current_avuri (request) -> set_current_a_v_uri (response)).

Also increased version of used nokogiri to be able to use globals.convert_response_tags_to -globals of the nokogiri.
